### PR TITLE
Working nix flake, both for building and development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ target/streams/compile/unmanagedJars/$global/streams/export
 test-cached
 eprover-ho
 portfolio/tmp
+result


### PR DESCRIPTION
I was passing by and noticed that your `flake.nix` didn't work (i.e. I couldn't use `nix build`) and that it was generally not very idiomatic I guess. So here is a modified version that I hope will satisfy your nix-desires.